### PR TITLE
Update screenshot handling to support new universal app format

### DIFF
--- a/view/app/app.js
+++ b/view/app/app.js
@@ -152,18 +152,18 @@ main((json) => {
                 .map((screenshot, i) => {
                     let imageURL;
 
-                    if (typeof screenshot === 'string' && isValidHTTPURL(screenshot)) {
+                    if (typeof screenshot === "string" && isValidHTTPURL(screenshot)) {
                         imageURL = screenshot;
-                    } else if (screenshot && typeof screenshot === 'object' && screenshot.imageURL) {
+                    } else if (screenshot && typeof screenshot === "object" && screenshot.imageURL) {
                         imageURL = screenshot.imageURL;
                     }
 
-                    if (!imageURL) return ''; // Skip invalid entries
+                    if (!imageURL) return ""; // Skip invalid entries
 
                     const altText = `${app.name} screenshot ${i + 1}`;
                     return `<img src="${imageURL}" alt="${altText}" class="screenshot">`;
                 })
-                .join('');
+                .join("");
 
             if (html) {
                 preview.querySelector("#screenshots").insertAdjacentHTML("beforeend", html);


### PR DESCRIPTION
According to the current AltStore developer documentation[^1], screenshots can be provided as either:

- A standard array of strings or objects (for iPhone)
- A universal app object with `iphone` and `ipad` keys, where iPad screenshots must include explicit width and height

<details>
<summary>Corresponding TypeScript type</summary>

```typescript
interface imageWithSize {
  imageURL: string
  width?: number
  height?: number
}

interface ScreenshotsClass {
  iphone: (imageWithSize | string)[]
  ipad: Required<imageWithSize>[]
}
```
</details>

This update refactors rendering to handle both formats and only processes iPhone screenshots in the universal apps format.

---

**Test Sources (current deployment will fail):**

- ```
  https://raw.githubusercontent.com/maxchang3/ani-altstore-source/main/generated/apps.json
  ```
  -
    ```
    /view/app/?source=https://raw.githubusercontent.com/maxchang3/ani-altstore-source/main/generated/apps.json&id=org.openani.Animeko
    ```
- ```
  https://raw.githubusercontent.com/RajnishOne/altstore-releases/main/altstore-pal.json
  ```
  - 
    ```
    /view/app/?source=https://raw.githubusercontent.com/RajnishOne/altstore-releases/main/altstore-pal.json&id=com.bluematter.qbitconnect
    ```

[^1]: https://faq.altstore.io/developers/make-a-source#screenshots