### PR TITLE
Refactor screenshot handling into shared utility function

### DIFF
--- a/view/all-apps/all-apps.js
+++ b/view/all-apps/all-apps.js
@@ -6,7 +6,7 @@
 //  MIT License.
 //
 
-import { insertNavigationBar, isValidHTTPURL } from "../../common/modules/utilities.js";
+import { insertNavigationBar, processScreenshots } from "../../common/modules/utilities.js";
 import { AppHeader } from "../../common/components/AppHeader.js";
 import { main } from "../../common/modules/main.js";
 
@@ -27,25 +27,12 @@ main((json) => {
         <div class="app-container">
             ${AppHeader(app, "..")}
             <p style="text-align: center; font-size: 0.9em;">${app.subtitle ?? ""}</p>`;
-        if (app.screenshots) { // New
+
+        const screenshotsHTML = processScreenshots(app, 2);
+        if (screenshotsHTML) {
             html += `
-            <div class="screenshots">`;
-            for (let i = 0; i < app.screenshots.length, i < 2; i++) {
-                const screenshot = app.screenshots[i];
-                if (!screenshot) return;
-                if (screenshot.imageURL) html += `
-                <img src="${screenshot.imageURL}" class="screenshot">`;
-                else if (isValidHTTPURL(screenshot)) html += `
-                <img src="${screenshot}" class="screenshot">`;
-            }
-            html += `
-            </div>`;
-        } else if (app.screenshotURLs) { // Legacy
-            html += `
-            <div class="screenshots">`;
-            for (let i = 0; i < app.screenshotURLs.length, i < 2; i++) if (app.screenshotURLs[i]) html += `
-                <img src="${app.screenshotURLs[i]}" class="screenshot">`;
-            html += `
+            <div class="screenshots">
+                ${screenshotsHTML}
             </div>`;
         }
         html += `

--- a/view/app/app.js
+++ b/view/app/app.js
@@ -7,7 +7,7 @@
 //
 
 import { urlSearchParams, sourceURL } from "../../common/modules/constants.js";
-import { formatString, insertSpaceInCamelString, insertSpaceInSnakeString, formatVersionDate, open, setTintColor, isValidHTTPURL, showAddToAltStoreAlert, json } from "../../common/modules/utilities.js";
+import { formatString, insertSpaceInCamelString, insertSpaceInSnakeString, formatVersionDate, open, setTintColor, showAddToAltStoreAlert, json, processScreenshots } from "../../common/modules/utilities.js";
 import { main } from "../../common/modules/main.js";
 import { AppPermissionItem } from "../../common/components/AppPermissionItem.js";
 import UIAlert from "../../common/vendor/uialert.js/uialert.js";
@@ -142,51 +142,9 @@ main((json) => {
     // Subtitle
     preview.querySelector("#subtitle").textContent = app.subtitle;
     // Screenshots
-    // New format with support for universal apps
-    if (app.screenshots) {
-        // Helper function to process screenshot array
-        const processScreenshotArray = (screenshots) => {
-            if (!Array.isArray(screenshots) || !screenshots.length) return;
-
-            const html = screenshots
-                .map((screenshot, i) => {
-                    let imageURL;
-
-                    if (typeof screenshot === "string" && isValidHTTPURL(screenshot)) {
-                        imageURL = screenshot;
-                    } else if (screenshot && typeof screenshot === "object" && screenshot.imageURL) {
-                        imageURL = screenshot.imageURL;
-                    }
-
-                    if (!imageURL) return ""; // Skip invalid entries
-
-                    const altText = `${app.name} screenshot ${i + 1}`;
-                    return `<img src="${imageURL}" alt="${altText}" class="screenshot">`;
-                })
-                .join("");
-
-            if (html) {
-                preview.querySelector("#screenshots").insertAdjacentHTML("beforeend", html);
-            }
-        };
-
-        if (Array.isArray(app.screenshots)) {
-            // Standard format: array of strings or objects
-            processScreenshotArray(app.screenshots);
-        } else if (app.screenshots && typeof app.screenshots === 'object') {
-            // Universal Apps format: object with iphone and ipad keys
-            // Only process iPhone screenshots as requested
-            if (app.screenshots.iphone && Array.isArray(app.screenshots.iphone)) {
-                processScreenshotArray(app.screenshots.iphone);
-            }
-        }
-    } else if (app.screenshotURLs) {
-        // Legacy format
-        app.screenshotURLs.forEach((url, i) => {
-            preview.querySelector("#screenshots").insertAdjacentHTML("beforeend", `
-                <img src="${url}" alt="${app.name} screenshot ${i + 1}" class="screenshot">
-            `);
-        });
+    const screenshotsHTML = processScreenshots(app);
+    if (screenshotsHTML) {
+        preview.querySelector("#screenshots").insertAdjacentHTML("beforeend", screenshotsHTML);
     }
     // Description
     const previewDescription = preview.querySelector("#description");


### PR DESCRIPTION
In #7, I missed updating the logic for `all-apps/`. Since both `all-apps/` and `apps/` were using the same screenshot processing logic, I’ve now extracted it into a shared utility function in `utilities.js`.

---

**Test Sources (current deployment will fail):**

- ```
  https://raw.githubusercontent.com/maxchang3/ani-altstore-source/main/generated/apps.json
  ```
  -
    ```
    /view/all-apps/?source=https://raw.githubusercontent.com/maxchang3/ani-altstore-source/main/generated/apps.json&id=org.openani.Animeko
    ```
- ```
  https://raw.githubusercontent.com/RajnishOne/altstore-releases/main/altstore-pal.json
  ```
  - 
    ```
    /view/all-apps/?source=https://raw.githubusercontent.com/RajnishOne/altstore-releases/main/altstore-pal.json&id=com.bluematter.qbitconnect
    ```